### PR TITLE
Added package.json and fixed up wscript so the package can be published to the npm repo

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,21 @@
+{
+    "author": "Ben Noordhuis <info@bnoordhuis.nl> (http://bnoordhuis.nl/)",
+    "name": "unix-dgram",
+    "version": "0.0.1",
+    "description": "Unix datagram socket",
+    "main": "src/unix_dgram",
+    "homepage": "https://github.com/bnoordhuis/node-unix-dgram/",
+    "repository": {
+        "type": "git",
+        "url": "git://github.com/bnoordhuis/node-unix-dgram.git"
+    },
+    "scripts": {
+        "preinstall": "node-waf configure build"
+    },
+    "engines": {
+        "node": ">= 0.4.0"
+    },
+    "dependencies": {},
+    "devDependencies": {},
+    "optionalDependencies": {}
+}

--- a/src/unix_dgram.js
+++ b/src/unix_dgram.js
@@ -2,7 +2,15 @@ var events = require('events');
 var dgram = require('dgram');
 var util = require('util');
 
-var binding = require(__dirname + '/unix_dgram.node');
+/*
+ * For some reason node-waf outputs the binding to different directories under node.js 0.4 and 0.6:
+ */
+var binding;
+try {
+    binding = require(__dirname + '/../build/Release/unix_dgram.node');
+} catch (e) {
+    binding = require(__dirname + '/../build/default/unix_dgram.node');
+}
 
 var SOCK_DGRAM  = binding.SOCK_DGRAM;
 var AF_UNIX     = binding.AF_UNIX;

--- a/test/test-dgram-unix.js
+++ b/test/test-dgram-unix.js
@@ -1,6 +1,6 @@
 SOCKNAME = '/tmp/unix_dgram.sock';
 
-var unix = require('../build/default/unix_dgram');
+var unix = require('../src/unix_dgram');
 
 var server = unix.createSocket('unix_dgram', function(buf, rinfo) {
   console.error('server recv', arguments);

--- a/wscript
+++ b/wscript
@@ -1,7 +1,6 @@
-def copy_files():
-  # waf is such a POS...
-  import shutil
-  shutil.copy('src/unix_dgram.js', 'build/default')
+srcdir = "."
+blddir = "build"
+VERSION = "0.0.1"
 
 def set_options(ctx):
   ctx.tool_options('compiler_cxx')
@@ -14,5 +13,3 @@ def build(ctx):
   t = ctx.new_task_gen('cxx', 'shlib', 'node_addon')
   t.target = 'unix_dgram'
   t.source = 'src/unix_dgram.cc'
-  ctx.install_files('${PREFIX}', 'src/*.js')
-  copy_files()


### PR DESCRIPTION
I admit that I don't really know what I'm doing wrt. `node-waf` and friends, but this seems to work under both node 0.4.x and 0.6.x.

I've published the package as `unix-dgram-papandreou` to test the publication itself. Will unpublish that when there's an official one with the bnoordhuis stamp of approval :)
