### PR TITLE
use NAN for Node 0.8->0.11+ compatibility

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -2,7 +2,10 @@
   'targets': [
     {
       'target_name': 'unix_dgram',
-      'sources': [ 'src/unix_dgram.cc' ]
+      'sources': [ 'src/unix_dgram.cc' ],
+      'include_dirs': [
+        '<!(node -e "require(\'nan\')")'
+      ]
     }
   ]
 }

--- a/package.json
+++ b/package.json
@@ -20,7 +20,13 @@
   "engines": {
     "node": ">=0.7.9"
   },
-  "dependencies": {},
+  "dependencies": {
+    "bindings": "~1.1.1",
+    "nan": "~0.7.0"
+  },
   "devDependencies": {},
-  "optionalDependencies": {}
+  "optionalDependencies": {},
+  "scripts": {
+    "test": "node test/*.js"
+  }
 }

--- a/src/unix_dgram.js
+++ b/src/unix_dgram.js
@@ -1,13 +1,7 @@
 var events = require('events');
 var dgram = require('dgram');
 var util = require('util');
-
-var binding;
-try {
-  binding = require(__dirname + '/../build/Release/unix_dgram.node');
-} catch (e) {
-  binding = require(__dirname + '/../build/Debug/unix_dgram.node');
-}
+var binding = require('bindings')('unix_dgram.node');
 
 var SOCK_DGRAM  = binding.SOCK_DGRAM;
 var AF_UNIX     = binding.AF_UNIX;

--- a/test/test-dgram-unix.js
+++ b/test/test-dgram-unix.js
@@ -15,7 +15,7 @@ process.on('exit', function() {
 try { fs.unlinkSync(SOCKNAME); } catch (e) { /* swallow */ }
 
 var server = unix.createSocket('unix_dgram', function(buf, rinfo) {
-  console.error('server recv', arguments);
+  console.error('server recv', '' + buf, arguments);
   assert.equal('' + buf, 'PING');
   seenPing = true;
   server.close();


### PR DESCRIPTION
Interested in this at all? I've bumped into problems with upstream dependents using unix-dgram and not having 0.11 compatibility.

Tests pass on all the versions I've tested:

```
Node@master  : PASS wrote output to /tmp/unix-dgram-dnt-master.out
Node@v0.11.9 : PASS wrote output to /tmp/unix-dgram-dnt-v0.11.9.out
Node@v0.11.8 : PASS wrote output to /tmp/unix-dgram-dnt-v0.11.8.out
Node@v0.11.7 : PASS wrote output to /tmp/unix-dgram-dnt-v0.11.7.out
Node@v0.11.6 : PASS wrote output to /tmp/unix-dgram-dnt-v0.11.6.out
Node@v0.11.5 : PASS wrote output to /tmp/unix-dgram-dnt-v0.11.5.out
Node@v0.11.4 : PASS wrote output to /tmp/unix-dgram-dnt-v0.11.4.out
Node@v0.10.22: PASS wrote output to /tmp/unix-dgram-dnt-v0.10.22.out
Node@v0.10.21: PASS wrote output to /tmp/unix-dgram-dnt-v0.10.21.out
Node@v0.10.20: PASS wrote output to /tmp/unix-dgram-dnt-v0.10.20.out
Node@v0.10.19: PASS wrote output to /tmp/unix-dgram-dnt-v0.10.19.out
Node@v0.10.18: PASS wrote output to /tmp/unix-dgram-dnt-v0.10.18.out
Node@v0.8.26 : PASS wrote output to /tmp/unix-dgram-dnt-v0.8.26.out
Node@v0.8.25 : PASS wrote output to /tmp/unix-dgram-dnt-v0.8.25.out
Node@v0.8.24 : PASS wrote output to /tmp/unix-dgram-dnt-v0.8.24.out
Node@v0.8.23 : PASS wrote output to /tmp/unix-dgram-dnt-v0.8.23.out
Node@v0.8.22 : PASS wrote output to /tmp/unix-dgram-dnt-v0.8.22.out
Took 10s to run 17 versions of Node
```
