### PR TITLE
WIP: Implement connect

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,12 +43,57 @@ first argument.
 Create a server at `path`.  Emits a `'listening'` event on success or
 an `'error'` event if the `bind(2)` system call fails.
 
-### socket.send(buf, offset, length, path, [callback]);
+### socket.connect(remote_path)
+
+Associate a socket with a remote path so you can send a message without setting
+the remote path. Once the socket is **connected** it emits a `'connect'` event.
+It also allows to perform some kind of congestion control as it emits a
+`'congestion'` event when the receiving buffer is full, and a `'writable'` event
+when it stops being full.
+
+### socket.send(buf, [callback])
+
+Only to be used with **connected** sockets. It sends a message to the remote
+path associated with the socket
+
+Example:
+
+    var unix = require('unix-dgram');
+
+    var client = unix.createSocket('unix_dgram');
+
+    client.on('error', function(err) {
+        console.error(err);
+    });
+
+    client.on('connect', function() {
+        console.log('connected');
+        client.on('congestion', function() {
+            console.log('congestion');
+            /* The server is not accepting data */
+        });
+
+        client.on('writable', function() {
+            console.log('writable');
+            /* The server can accept data */
+        });
+
+        var message = new Buffer('PING');
+        client.send(message);
+    });
+
+    client.connect('/tmp/server');
+
+
+### socket.send_to(buf, offset, length, path, [callback]);
 
 Send a message to the server listening at `path`.
 
 `buf` is a `Buffer` object containing the message to send, `offset` is
 the offset into the buffer and `length` is the length of the message.
+
+For backwards compatibility, you can still use the `socket.send` function with
+this same signature.
 
 Example:
 

--- a/lib/unix_dgram.js
+++ b/lib/unix_dgram.js
@@ -8,6 +8,8 @@ var AF_UNIX     = binding.AF_UNIX;
 
 var socket  = binding.socket;
 var bind    = binding.bind;
+var connect = binding.connect;
+var sendto  = binding.sendto;
 var send    = binding.send;
 var close   = binding.close;
 
@@ -30,6 +32,10 @@ function recv(status, buf, path) {
 }
 
 
+function writable() {
+  this.emit('writable');
+}
+
 exports.createSocket = function(type, listener) {
   if (type == 'udp4' || type == 'udp6')
     return dgram.createSocket(type, listener);
@@ -42,7 +48,7 @@ function Socket(type, listener) {
   if (type != 'unix_dgram')
     throw new Error('Unsupported socket type: ' + type);
 
-  var err = socket(AF_UNIX, SOCK_DGRAM, 0, recv.bind(this));
+  var err = socket(AF_UNIX, SOCK_DGRAM, 0, recv.bind(this), writable.bind(this));
   if (err < 0)
     throw errnoException(err, 'socket');
 
@@ -63,12 +69,30 @@ Socket.prototype.bind = function(path) {
     this.emit('listening');
 };
 
+Socket.prototype.connect = function(path) {
+  var err = connect(this.fd, path);
+  if (err < 0) {
+    this.emit('error', errnoException(err, 'connect'));
+  } else {
+    this.connected = true;
+    this.emit('connect');
+  }
+};
 
 Socket.prototype.send = function(buf, offset, length, path, callback) {
+  var err;
+  if (this.connected) {
+    err = send(this.fd, buf);
+    callback = offset;
+  } else {
+    err = sendto(this.fd, buf, offset, length, path);
+  }
+
   // FIXME defer error and callback to next tick?
-  var err = send(this.fd, buf, offset, length, path);
   if (err < 0)
     this.emit('error', errnoException(err, 'send'));
+  else if (err === 1)
+    this.emit('congestion');
   else if (typeof callback === 'function')
     callback();
 };

--- a/package.json
+++ b/package.json
@@ -27,6 +27,6 @@
   "devDependencies": {},
   "optionalDependencies": {},
   "scripts": {
-    "test": "node test/*.js"
+    "test": "node test/test-dgram-unix.js && node test/test-connect.js"
   }
 }

--- a/test/test-connect.js
+++ b/test/test-connect.js
@@ -1,0 +1,65 @@
+var assert = require('assert');
+var fs = require('fs');
+
+var unix = require('../lib/unix_dgram');
+var SOCKNAME = '/tmp/unix_dgram.sock';
+
+var sentCount = 0;
+var seenCount = 0;
+
+process.on('exit', function() {
+  assert(seenCount === sentCount);
+});
+
+try { fs.unlinkSync(SOCKNAME); } catch (e) { /* swallow */ }
+
+var server = unix.createSocket('unix_dgram', function(buf, rinfo) {
+  console.error('server recv', '' + buf, arguments);
+  assert.equal('' + buf, 'PING' + seenCount);
+  if (++ seenCount === 12) {
+    server.close();
+    client.close();
+  }
+});
+server.bind(SOCKNAME);
+
+var client = unix.createSocket('unix_dgram', function(buf, rinfo) {
+  console.error('client recv', arguments);
+  assert(0);
+});
+
+client.on('error', function(err) {
+  console.error(err);
+  assert(0);
+});
+
+client.on('connect', function() {
+  console.error('connected');
+  client.on('congestion', function() {
+    console.error('congestion');
+    client.on('writable', function() {
+      console.error('writable');
+      var msg = Buffer('PING' + sentCount);
+      client.send(msg, function() {
+        console.error('client send', msg.toString());
+        ++ sentCount;
+      });
+    });
+  });
+
+  var i = 0;
+  var msg;
+  /*
+   * Usually /proc/sys/net/unix/max_dgram_qlen is 10 so one that's being processed, 10 in the
+   * recv queue and the 12th is dropped
+   */
+  while (i ++ < 12) {
+    msg = Buffer('PING' + sentCount);
+    client.send(msg, function() {
+      console.error('client send', msg.toString());
+      ++ sentCount;
+    });
+  }
+});
+
+client.connect(SOCKNAME);


### PR DESCRIPTION
Implementing connect in dgram sockets allow us to have some kind of flow control as we'll receive EAGAIN in case the server buffer is full and a WRITABLE event once it's not.
Three new events are added:
`connect`: if connect succeeds
`congestion`: If the server buffer is full
`writable`: When the server accepts data again.

Basic example:

```
var unix = require('../lib/unix_dgram');

var client = unix.createSocket('unix_dgram');

client.on('error', function(err) {
    console.error(err);
});

client.on('connect', function() {
    console.log('connected');
    client.on('congestion', function() {
        console.log('congestion');
        /* The server is not accepting data */
    });

    client.on('writable', function() {
        console.log('writable');
        /* The server can accept data */
    });

    var message = new Buffer('PING');
    client.send(message);
    client.close();
});

client.connect('/tmp/server');
```

It tries to address bug #4
