### PR TITLE
RFC: support other protocol families

### DIFF
--- a/lib/unix_dgram.js
+++ b/lib/unix_dgram.js
@@ -6,13 +6,14 @@ var binding = require('bindings')('unix_dgram.node');
 var SOCK_DGRAM  = binding.SOCK_DGRAM;
 var AF_UNIX     = binding.AF_UNIX;
 
-var socket     = binding.socket;
-var bind       = binding.bind;
-var connect    = binding.connect;
-var sendto     = binding.sendto;
-var send       = binding.send;
-var close      = binding.close;
-var toUnixAddress = binding.toUnixAddress;
+var socket          = binding.socket;
+var bind            = binding.bind;
+var connect         = binding.connect;
+var sendto          = binding.sendto;
+var send            = binding.send;
+var close           = binding.close;
+var toUnixAddress   = binding.toUnixAddress;
+var fromUnixAddress = binding.fromUnixAddress;
 
 
 function errnoException(errorno, syscall) {
@@ -22,16 +23,14 @@ function errnoException(errorno, syscall) {
   return e;
 }
 
-
-function recv(status, buf, path) {
+function recv(status, buf, address) {
   var rinfo = {
     size: buf.length,
     address: {},
-    path : path
+    path : fromUnixAddress(address) || null
   };
   this.emit('message', buf, rinfo);
 }
-
 
 function writable() {
   this.emit('writable');


### PR DESCRIPTION
I'm studying how to modify this module to support other protocol families apart from `AF_UNIX` while still using `SOCK_DGRAM`. I have 2 options: 1) copy most of the code from this module and replace the functionality related to AF_UNIX . 2) Try to make most of the code independent of the protocol family so any protocol family can easily be added.

Does this sound reasonable? Does trying #2 make any sense?

In this PR I've tried to accomplish this for bind, connect and sendto. I'm still trying to figure out a simple way to implement the reception. What do you think?

Thanks
