### PR TITLE
src: fix compilation error on node 0.11.13

### DIFF
--- a/src/unix_dgram.cc
+++ b/src/unix_dgram.cc
@@ -116,7 +116,7 @@ void OnRecv(SocketContext* sc) {
     }
   }
 
-  argv[0] = NanNew(err);
+  argv[0] = NanNew<Integer>(err);
 
   TryCatch tc;
   NanNew(sc->recv_cb_)->Call(NanGetCurrentContext()->Global(),


### PR DESCRIPTION
The compiler was complaining when building the module for node 0.11.13

../src/unix_dgram.cc:119:13: error: call to 'NanNew' is ambiguous
  argv[0] = NanNew(err);
            ^~~~~~
../node_modules/nan/nan.h:1249:36: note: candidate function
  NAN_INLINE v8::Localv8::Number NanNew(double val) {
                                   ^
../node_modules/nan/nan.h:1253:37: note: candidate function
  NAN_INLINE v8::Localv8::Integer NanNew(int val) {
                                    ^
../node_modules/nan/nan.h:1257:36: note: candidate function
  NAN_INLINE v8::Localv8::Uint32 NanNew(unsigned int val) {
                                   ^
../node_modules/nan/nan.h:1261:37: note: candidate function
  NAN_INLINE v8::Localv8::Boolean NanNew(bool val) {
                                    ^
