### PR TITLE
builds with node 6.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   },
   "dependencies": {
     "bindings": "~1.1.1",
-    "nan": "~2.0.8"
+    "nan": "^2.0.8"
   },
   "devDependencies": {},
   "optionalDependencies": {},


### PR DESCRIPTION
For the just-released node.js 6.0.0 there was also an update to nan, 2.3.2. This PR loosens the dependency on nan so that a 6-compatible version can be pulled in.