### PR TITLE
src: return send error in callback if present

### DIFF
--- a/lib/unix_dgram.js
+++ b/lib/unix_dgram.js
@@ -89,12 +89,18 @@ Socket.prototype.send = function(buf, offset, length, path, callback) {
   }
 
   // FIXME defer error and callback to next tick?
-  if (err < 0)
-    this.emit('error', errnoException(err, 'send'));
-  else if (err === 1)
+  if (err < 0) {
+    var error = errnoException(err, 'send');
+    if (typeof callback === 'function') {
+      callback(error);
+    } else {
+      this.emit('error', error);
+    }
+  } else if (err === 1) {
     this.emit('congestion');
-  else if (typeof callback === 'function')
+  } else if (typeof callback === 'function') {
     callback();
+  }
 };
 
 

--- a/package.json
+++ b/package.json
@@ -27,6 +27,6 @@
   "devDependencies": {},
   "optionalDependencies": {},
   "scripts": {
-    "test": "node test/test-dgram-unix.js && node test/test-connect.js"
+    "test": "node test/test-dgram-unix.js && node test/test-connect.js && node test/test-send-error.js"
   }
 }

--- a/test/test-send-error.js
+++ b/test/test-send-error.js
@@ -1,0 +1,26 @@
+var assert = require('assert');
+var fs = require('fs');
+
+var unix = require('../lib/unix_dgram');
+var SOCKNAME = '/tmp/unix_dgram.sock';
+
+try { fs.unlinkSync(SOCKNAME); } catch (e) { /* swallow */ }
+
+var client = unix.createSocket('unix_dgram', function(buf, rinfo) {
+  console.error('client recv', arguments);
+  assert(0);
+});
+
+client.once('error', function(err) {
+  assert.ok(err);
+  client.once('error', function(err) {
+    assert.ifError(err);
+  });
+
+  client.send(Buffer('ERROR2'), 0, 6, SOCKNAME, function(err) {
+    assert.ok(err);
+    client.close();
+  });
+});
+
+client.send(Buffer('ERROR1'), 0, 6, SOCKNAME);


### PR DESCRIPTION
Otherwise emit an `error` event.

This behaviour emulates the behaviour of `udp` core module:
"If an error occurs and a callback is given, the error will be passed as
the first argument to the callback. If a callback is not given, the
error is emitted as an 'error' event on the socket object."