### PR TITLE
Upgrade dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,11 +18,11 @@
     "url": "git://github.com/bnoordhuis/node-unix-dgram.git"
   },
   "engines": {
-    "node": ">=0.7.9"
+    "node": ">=0.10.48"
   },
   "dependencies": {
-    "bindings": "~1.1.1",
-    "nan": "~2.3.2"
+    "bindings": "^1.3.0",
+    "nan": "^2.10.0"
   },
   "devDependencies": {},
   "optionalDependencies": {},


### PR DESCRIPTION
It appears things broke in the old NAN with the release of Node.js 10. I simply updated all deps to their latest versions, and tests still work. Doesn't get rid of all deprecation warnings.

I wonder if the path forward is N-API? It would further limit compatibility to Node.js >=6.x, but that'd also allow us to use the new Buffer APIs, fixing all deprecation warnings.