### PR TITLE
package.json: install a dummy on Windows

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -1,11 +1,20 @@
 {
-  'targets': [
-    {
-      'target_name': 'unix_dgram',
-      'sources': [ 'src/unix_dgram.cc' ],
-      'include_dirs': [
-        '<!(node -e "require(\'nan\')")'
-      ]
-    }
+  'conditions': [
+    [ 'OS!="win"', {
+      'targets': [ {
+          'target_name': 'unix_dgram',
+          'sources': [ 'src/unix_dgram.cc' ],
+          'include_dirs': [
+            '<!(node -e "require(\'nan\')")'
+          ]
+        } ]
+      }
+    ],
+    [ 'OS=="win"', {
+      'targets': [ {
+        'target_name': 'unix_dgram',
+        'sources': [ 'src/win_dummy.cc' ],
+      } ]
+    } ]
   ]
 }

--- a/lib/unix_dgram.js
+++ b/lib/unix_dgram.js
@@ -6,12 +6,17 @@ var binding = require('bindings')('unix_dgram.node');
 var SOCK_DGRAM  = binding.SOCK_DGRAM;
 var AF_UNIX     = binding.AF_UNIX;
 
-var socket  = binding.socket;
-var bind    = binding.bind;
-var connect = binding.connect;
-var sendto  = binding.sendto;
-var send    = binding.send;
-var close   = binding.close;
+var socket  = binding.socket || unsupported;
+var bind    = binding.bind || unsupported;
+var connect = binding.connect || unsupported;
+var sendto  = binding.sendto || unsupported;
+var send    = binding.send || unsupported;
+var close   = binding.close || unsupported;
+
+
+function unsupported() {
+  throw new Error('Unix datagrams not available on this platform');
+}
 
 
 function errnoException(errorno, syscall) {

--- a/src/win_dummy.cc
+++ b/src/win_dummy.cc
@@ -1,0 +1,7 @@
+#include <node.h>
+
+namespace {
+void Initialize(v8::Local<v8::Object> target) {}
+}
+
+NODE_MODULE(unix_dgram, Initialize)


### PR DESCRIPTION
The original code wouldn't build on Windows at all as it does not support Unix datagrams.
Not building anything caused node-gyp to complain that it couldn't find a target.
Building a dummy module on Windows instead.