### PR TITLE
feat: add typescript support

### DIFF
--- a/lib/unix_dgram.d.ts
+++ b/lib/unix_dgram.d.ts
@@ -1,7 +1,6 @@
 /// <reference types="node" />
 
 import { EventEmitter } from "events";
-import { AddressInfo } from "net";
 import TypedEmitter from "typed-emitter";
 
 export function createSocket(
@@ -11,7 +10,7 @@ export function createSocket(
 
 export interface RemoteInfo {
   size: number;
-  address: AddressInfo | {};
+  address: Record<string, never>;
   path: string;
 }
 
@@ -44,4 +43,3 @@ export class Socket
   ): void;
   close(): void;
 }
-

--- a/lib/unix_dgram.d.ts
+++ b/lib/unix_dgram.d.ts
@@ -1,0 +1,47 @@
+/// <reference types="node" />
+
+import { EventEmitter } from "events";
+import { AddressInfo } from "net";
+import TypedEmitter from "typed-emitter";
+
+export function createSocket(
+  type: "unix_dgram",
+  listener?: (msg: Buffer, rinfo: RemoteInfo) => void,
+): Socket;
+
+export interface RemoteInfo {
+  size: number;
+  address: AddressInfo | {};
+  path: string;
+}
+
+export type SocketEvents = {
+  close: () => void;
+  connect: () => void;
+  error: (err: Error) => void;
+  listening: () => void;
+  message: (msg: Buffer, rinfo: RemoteInfo) => void;
+};
+
+export class Socket
+  extends (EventEmitter as new () => TypedEmitter<SocketEvents>) {
+  bind(path: string): void;
+  connect(path: string): void;
+  send(
+    buf: Buffer,
+    offset: number,
+    length: number,
+    path: string,
+    callback?: (err: Error | null) => void,
+  ): void;
+  send(buf: Buffer, callback?: (err: Error | null) => void): void;
+  sendto(
+    buf: Buffer,
+    offset: number,
+    length: number,
+    path: string,
+    callback?: (err: Error | null) => void,
+  ): void;
+  close(): void;
+}
+

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   "version": "2.0.7",
   "description": "Unix datagram socket",
   "main": "lib/unix_dgram",
+  "types": "lib/unix_dgram.d.ts",
   "homepage": "https://github.com/bnoordhuis/node-unix-dgram",
   "license": {
     "type": "ISC",
@@ -24,7 +25,9 @@
     "bindings": "^1.5.0",
     "nan": "^2.20.0"
   },
-  "devDependencies": {},
+  "devDependencies": {
+    "typed-emitter": "^2.1.0"
+  },
   "optionalDependencies": {},
   "scripts": {
     "test": "node test/test-dgram-unix.js && node test/test-connect.js && node test/test-connect-callback.js && node test/test-send-error.js"


### PR DESCRIPTION
Tested locally by running `pnpm link unix-dgram ~dev/node-unix-dgram` and confirming that my typescript (admittedly a light user of the library) type-checks.